### PR TITLE
Rearrange ArrayOf and remove filter

### DIFF
--- a/src/ArrayOf.php
+++ b/src/ArrayOf.php
@@ -34,7 +34,14 @@ abstract class ArrayOf extends ArrayObject
             throw InvalidEnforcementType::forType($this->typeToEnforce());
         }
 
-        parent::__construct($this->filteredInput($input));
+        array_map(function ($item): void {
+            // Enforce type of array items
+            if (!$this->checkType($item)) {
+                throw InvalidInstantiationType::forType(static::class, static::getType($item), $this->typeToEnforce());
+            }
+        }, $input);
+
+        parent::__construct($input);
     }
 
     private function checkEnforcementType(): bool
@@ -55,21 +62,6 @@ abstract class ArrayOf extends ArrayObject
     private function checkForScalar(): bool
     {
         return in_array($this->typeToEnforce(), self::POSSIBLE_SCALARS);
-    }
-
-    private function filteredInput(array $input = []): array
-    {
-        $filteredInput = [];
-        foreach ($input as $key => $item) {
-            // Enforce type of array items
-            if (!$this->checkType($item)) {
-                throw InvalidInstantiationType::forType(static::class, static::getType($item), $this->typeToEnforce());
-            }
-
-            $filteredInput[$key] = $item;
-        }
-
-        return $filteredInput;
     }
 
     /**

--- a/src/ArrayOf.php
+++ b/src/ArrayOf.php
@@ -28,27 +28,42 @@ abstract class ArrayOf extends ArrayObject
      * @throws InvalidEnforcementType
      * @throws InvalidInstantiationType
      */
-    public function __construct(array $input = [], ?callable $filter = null)
+    public function __construct(array $input = [])
     {
         if (!$this->checkEnforcementType()) {
             throw InvalidEnforcementType::forType($this->typeToEnforce());
         }
 
-        parent::__construct($this->filteredInput($input, $filter));
+        parent::__construct($this->filteredInput($input));
     }
 
-    private function filteredInput(array $input = [], ?callable $filter = null): array
+    private function checkEnforcementType(): bool
+    {
+        if ($this->checkForValidClass()) {
+            return true;
+        }
+
+        return $this->checkForScalar();
+    }
+
+    private function checkForValidClass(): bool
+    {
+        return class_exists($this->typeToEnforce())
+            || interface_exists($this->typeToEnforce());
+    }
+
+    private function checkForScalar(): bool
+    {
+        return in_array($this->typeToEnforce(), self::POSSIBLE_SCALARS);
+    }
+
+    private function filteredInput(array $input = []): array
     {
         $filteredInput = [];
         foreach ($input as $key => $item) {
             // Enforce type of array items
             if (!$this->checkType($item)) {
                 throw InvalidInstantiationType::forType(static::class, static::getType($item), $this->typeToEnforce());
-            }
-
-            // Allow input to be filtered by callback
-            if ($filter !== null && $filter($item) === false) {
-                continue;
             }
 
             $filteredInput[$key] = $item;
@@ -70,15 +85,6 @@ abstract class ArrayOf extends ArrayObject
         return static::getType($variable) === $this->typeToEnforce();
     }
 
-    private function checkEnforcementType(): bool
-    {
-        if ($this->checkForValidClass()) {
-            return true;
-        }
-
-        return $this->checkForScalar();
-    }
-
     /**
      * @param mixed $variable
      */
@@ -87,16 +93,5 @@ abstract class ArrayOf extends ArrayObject
         return is_object($variable)
             ? get_class($variable)
             : gettype($variable);
-    }
-
-    private function checkForValidClass(): bool
-    {
-        return class_exists($this->typeToEnforce())
-            || interface_exists($this->typeToEnforce());
-    }
-
-    private function checkForScalar(): bool
-    {
-        return in_array($this->typeToEnforce(), self::POSSIBLE_SCALARS);
     }
 }

--- a/tests/Unit/ArrayOfTest.php
+++ b/tests/Unit/ArrayOfTest.php
@@ -82,27 +82,6 @@ final class ArrayOfTest extends TestCase
         self::assertTrue(isset($test[0]));
         self::assertFalse(isset($test[100]));
 
-        $i = 0;
-        foreach ($test as $item) {
-            $i++;
-        }
-        self::assertEquals(2, $i);
-    }
-
-    public function testFiltersInputBasedOnCallback(): void
-    {
-        $filterCallback = fn (SimpleObject $item) => ($item->getValue() === 'yes');
-
-        $test = new ValidClassArrayOf([
-            new SimpleObject('yes'),
-            new SimpleObject('no'),
-            new SimpleObject('yes'),
-            new SimpleObject('yes'),
-            new SimpleObject('no'),
-            new SimpleObject('yes'),
-            new SimpleObject('yes'),
-        ], $filterCallback);
-
-        self::assertEquals(5, count($test));
+        self::assertCount(2, $test);
     }
 }


### PR DESCRIPTION
## 📚 Description

Remove the `filter` callback from the `ArrayOf` constructor.

## 🔖 Changes

- Remove `?callable $filter` from the constructor
- Rearrange `ArrayOf` class
- Delete `testFiltersInputBasedOnCallback()` test
- Update `testCanUseAsArray()` test

## ⚠️ Extra

Not sure what to do with the method name `filteredInput()`, maybe rename it to `checkInput()`?
