### PR TITLE
Rename ArrayOf to AbstractArrayOf

### DIFF
--- a/src/AbstractArrayOf.php
+++ b/src/AbstractArrayOf.php
@@ -8,7 +8,7 @@ use ArrayObject;
 use ArrayOf\Exceptions\InvalidEnforcementType;
 use ArrayOf\Exceptions\InvalidInstantiationType;
 
-abstract class ArrayOf extends ArrayObject
+abstract class AbstractArrayOf extends ArrayObject
 {
     protected const SCALAR_BOOLEAN = 'boolean';
     protected const SCALAR_INTEGER = 'integer';
@@ -34,12 +34,7 @@ abstract class ArrayOf extends ArrayObject
             throw InvalidEnforcementType::forType($this->typeToEnforce());
         }
 
-        array_map(function ($item): void {
-            // Enforce type of array items
-            if (!$this->checkType($item)) {
-                throw InvalidInstantiationType::forType(static::class, static::getType($item), $this->typeToEnforce());
-            }
-        }, $input);
+        $this->guardEnforceType($input);
 
         parent::__construct($input);
     }
@@ -62,6 +57,15 @@ abstract class ArrayOf extends ArrayObject
     private function checkForScalar(): bool
     {
         return in_array($this->typeToEnforce(), self::POSSIBLE_SCALARS);
+    }
+
+    private function guardEnforceType(array $input): void
+    {
+        array_map(function ($item): void {
+            if (!$this->checkType($item)) {
+                throw InvalidInstantiationType::forType(static::class, static::getType($item), $this->typeToEnforce());
+            }
+        }, $input);
     }
 
     /**

--- a/src/Scalars/Immutable/ImmutableArrayOfBoolean.php
+++ b/src/Scalars/Immutable/ImmutableArrayOfBoolean.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace ArrayOf\Scalars\Immutable;
 
-use ArrayOf\ArrayOf;
+use ArrayOf\AbstractArrayOf;
 use ArrayOf\Traits\Immutable;
 
-final class ImmutableArrayOfBoolean extends ArrayOf
+final class ImmutableArrayOfBoolean extends AbstractArrayOf
 {
     use Immutable;
 

--- a/src/Scalars/Immutable/ImmutableArrayOfFloat.php
+++ b/src/Scalars/Immutable/ImmutableArrayOfFloat.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace ArrayOf\Scalars\Immutable;
 
-use ArrayOf\ArrayOf;
+use ArrayOf\AbstractArrayOf;
 use ArrayOf\Traits\Immutable;
 
-final class ImmutableArrayOfFloat extends ArrayOf
+final class ImmutableArrayOfFloat extends AbstractArrayOf
 {
     use Immutable;
 

--- a/src/Scalars/Immutable/ImmutableArrayOfInteger.php
+++ b/src/Scalars/Immutable/ImmutableArrayOfInteger.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace ArrayOf\Scalars\Immutable;
 
-use ArrayOf\ArrayOf;
+use ArrayOf\AbstractArrayOf;
 use ArrayOf\Traits\Immutable;
 
-final class ImmutableArrayOfInteger extends ArrayOf
+final class ImmutableArrayOfInteger extends AbstractArrayOf
 {
     use Immutable;
 

--- a/src/Scalars/Immutable/ImmutableArrayOfString.php
+++ b/src/Scalars/Immutable/ImmutableArrayOfString.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace ArrayOf\Scalars\Immutable;
 
-use ArrayOf\ArrayOf;
+use ArrayOf\AbstractArrayOf;
 use ArrayOf\Traits\Immutable;
 
-final class ImmutableArrayOfString extends ArrayOf
+final class ImmutableArrayOfString extends AbstractArrayOf
 {
     use Immutable;
 

--- a/src/Scalars/Mutable/ArrayOfBoolean.php
+++ b/src/Scalars/Mutable/ArrayOfBoolean.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace ArrayOf\Scalars\Mutable;
 
-use ArrayOf\ArrayOf;
+use ArrayOf\AbstractArrayOf;
 
-final class ArrayOfBoolean extends ArrayOf
+final class ArrayOfBoolean extends AbstractArrayOf
 {
     protected function typeToEnforce(): string
     {

--- a/src/Scalars/Mutable/ArrayOfFloat.php
+++ b/src/Scalars/Mutable/ArrayOfFloat.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace ArrayOf\Scalars\Mutable;
 
-use ArrayOf\ArrayOf;
+use ArrayOf\AbstractArrayOf;
 
-final class ArrayOfFloat extends ArrayOf
+final class ArrayOfFloat extends AbstractArrayOf
 {
     protected function typeToEnforce(): string
     {

--- a/src/Scalars/Mutable/ArrayOfInteger.php
+++ b/src/Scalars/Mutable/ArrayOfInteger.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace ArrayOf\Scalars\Mutable;
 
-use ArrayOf\ArrayOf;
+use ArrayOf\AbstractArrayOf;
 
-final class ArrayOfInteger extends ArrayOf
+final class ArrayOfInteger extends AbstractArrayOf
 {
     protected function typeToEnforce(): string
     {

--- a/src/Scalars/Mutable/ArrayOfString.php
+++ b/src/Scalars/Mutable/ArrayOfString.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace ArrayOf\Scalars\Mutable;
 
-use ArrayOf\ArrayOf;
+use ArrayOf\AbstractArrayOf;
 
-final class ArrayOfString extends ArrayOf
+final class ArrayOfString extends AbstractArrayOf
 {
     protected function typeToEnforce(): string
     {

--- a/tests/Unit/ArrayOfTest.php
+++ b/tests/Unit/ArrayOfTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ArrayOfTest\Unit;
 
-use ArrayOf\ArrayOf;
+use ArrayOf\AbstractArrayOf;
 use ArrayOf\Exceptions\InvalidEnforcementType;
 use ArrayOf\Scalars\Mutable\ArrayOfString;
 use ArrayOfTest\Unit\Fixtures\ArrayOfSimpleObjects;
@@ -16,10 +16,10 @@ final class ArrayOfTest extends TestCase
     public function testValidEnforcementTypes(): void
     {
         $validScalar = new ArrayOfString();
-        self::assertInstanceOf(ArrayOf::class, $validScalar);
+        self::assertInstanceOf(AbstractArrayOf::class, $validScalar);
 
         $validClass = new ArrayOfSimpleObjects();
-        self::assertInstanceOf(ArrayOf::class, $validClass);
+        self::assertInstanceOf(AbstractArrayOf::class, $validClass);
     }
 
     public function testKeysArePreserved(): void
@@ -38,7 +38,7 @@ final class ArrayOfTest extends TestCase
     {
         $this->expectException(InvalidEnforcementType::class);
 
-        new class() extends ArrayOf {
+        new class() extends AbstractArrayOf {
             protected function typeToEnforce(): string
             {
                 return 'array';
@@ -50,7 +50,7 @@ final class ArrayOfTest extends TestCase
     {
         $this->expectException(InvalidEnforcementType::class);
 
-        new class([]) extends ArrayOf {
+        new class([]) extends AbstractArrayOf {
             protected function typeToEnforce(): string
             {
                 return 'InvalidClassName' . md5((string) time());
@@ -61,10 +61,10 @@ final class ArrayOfTest extends TestCase
     public function testValidInputTypes(): void
     {
         $scalars = new ArrayOfString(['test', 'test-again']);
-        self::assertInstanceOf(ArrayOf::class, $scalars);
+        self::assertInstanceOf(AbstractArrayOf::class, $scalars);
 
         $classes = new ArrayOfSimpleObjects([new SimpleObject(), new SimpleObject()]);
-        self::assertInstanceOf(ArrayOf::class, $classes);
+        self::assertInstanceOf(AbstractArrayOf::class, $classes);
     }
 
     public function testCanUseAsArray(): void

--- a/tests/Unit/Fixtures/ArrayOfSimpleObjects.php
+++ b/tests/Unit/Fixtures/ArrayOfSimpleObjects.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace ArrayOfTest\Unit\Fixtures;
 
-use ArrayOf\ArrayOf;
+use ArrayOf\AbstractArrayOf;
 
-final class ArrayOfSimpleObjects extends ArrayOf
+final class ArrayOfSimpleObjects extends AbstractArrayOf
 {
     protected function typeToEnforce(): string
     {

--- a/tests/Unit/Scalars/Mutable/ArrayOfBooleanTest.php
+++ b/tests/Unit/Scalars/Mutable/ArrayOfBooleanTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ArrayOfTest\Unit\Scalars\Mutable;
 
-use ArrayOf\ArrayOf;
+use ArrayOf\AbstractArrayOf;
 use ArrayOf\Exceptions\InvalidInstantiationType;
 use ArrayOf\Scalars\Mutable\ArrayOfBoolean;
 use Generator;
@@ -17,7 +17,7 @@ final class ArrayOfBooleanTest extends TestCase
     {
         $test = new ArrayOfBoolean([true]);
         self::assertInstanceOf(ArrayOfBoolean::class, $test);
-        self::assertInstanceOf(ArrayOf::class, $test);
+        self::assertInstanceOf(AbstractArrayOf::class, $test);
     }
 
     /**

--- a/tests/Unit/Scalars/Mutable/ArrayOfFloatTest.php
+++ b/tests/Unit/Scalars/Mutable/ArrayOfFloatTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ArrayOfTest\Unit\Scalars\Mutable;
 
-use ArrayOf\ArrayOf;
+use ArrayOf\AbstractArrayOf;
 use ArrayOf\Exceptions\InvalidInstantiationType;
 use ArrayOf\Scalars\Mutable\ArrayOfFloat;
 use Generator;
@@ -17,7 +17,7 @@ final class ArrayOfFloatTest extends TestCase
     {
         $test = new ArrayOfFloat([1.5]);
         self::assertInstanceOf(ArrayOfFloat::class, $test);
-        self::assertInstanceOf(ArrayOf::class, $test);
+        self::assertInstanceOf(AbstractArrayOf::class, $test);
     }
 
     /**

--- a/tests/Unit/Scalars/Mutable/ArrayOfIntegerTest.php
+++ b/tests/Unit/Scalars/Mutable/ArrayOfIntegerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ArrayOfTest\Unit\Scalars\Mutable;
 
-use ArrayOf\ArrayOf;
+use ArrayOf\AbstractArrayOf;
 use ArrayOf\Exceptions\InvalidInstantiationType;
 use ArrayOf\Scalars\Mutable\ArrayOfInteger;
 use Generator;
@@ -17,7 +17,7 @@ final class ArrayOfIntegerTest extends TestCase
     {
         $test = new ArrayOfInteger([1]);
         self::assertInstanceOf(ArrayOfInteger::class, $test);
-        self::assertInstanceOf(ArrayOf::class, $test);
+        self::assertInstanceOf(AbstractArrayOf::class, $test);
     }
 
     /**

--- a/tests/Unit/Scalars/Mutable/ArrayOfStringTest.php
+++ b/tests/Unit/Scalars/Mutable/ArrayOfStringTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ArrayOfTest\Unit\Scalars\Mutable;
 
-use ArrayOf\ArrayOf;
+use ArrayOf\AbstractArrayOf;
 use ArrayOf\Exceptions\InvalidInstantiationType;
 use ArrayOf\Scalars\Mutable\ArrayOfString;
 use Generator;
@@ -17,7 +17,7 @@ final class ArrayOfStringTest extends TestCase
     {
         $test = new ArrayOfString(['test']);
         self::assertInstanceOf(ArrayOfString::class, $test);
-        self::assertInstanceOf(ArrayOf::class, $test);
+        self::assertInstanceOf(AbstractArrayOf::class, $test);
     }
 
     /**


### PR DESCRIPTION
## 📚 Description

This PR resolves the https://github.com/Chemaclass/php-array-of/issues/4 issue.

## 🔖 Changes

- Rename `ArrayOf\ArrayOf` to `ArrayOf\AbstractArrayOf` class
- Move logic from constructor in`AbstractArrayOf` to a guard method
